### PR TITLE
Exclude unavailable GPUs from summary

### DIFF
--- a/gpu.py
+++ b/gpu.py
@@ -76,7 +76,7 @@ def pretty(gpu2status2user2count: Dict[str, Dict[str, Dict[str, int]]], gpu2coun
   print('-' * 126)
   allgpu: Set[str] = set(gpu2count.keys())
   inusegpu: Set[str] = set(gpu2status2user2count.keys())
-  for gpu in list(inusegpu) + list(allgpu - inusegpu):
+  for gpu in sorted(list(inusegpu) + list(allgpu - inusegpu)):
     status2user2count = gpu2status2user2count[gpu]
     status2count = defaultdict(lambda: 0)
     status2count.update({s: sum(u2c.values()) for s, u2c in status2user2count.items()})

--- a/gpu.py
+++ b/gpu.py
@@ -101,7 +101,6 @@ def get_gpu_config(filename: str = '/etc/slurm/gres.conf') -> Tuple[Dict[str, Di
     tuple(n.split(";"))
     for n in p.stdout.read().decode('utf-8').strip().splitlines()
   )
-  print(all_nodes_and_states)
   available_nodes = {
     n[0]
     for n in all_nodes_and_states


### PR DESCRIPTION
Only count GPUs from nodes in generally available states (i.e., mix, alloc, idle).  This excludes nodes that are down/draining.